### PR TITLE
Use our own repo's module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dmarkham/enumer
+module github.com/e-flux-platform/enumer
 
 require (
 	github.com/pascaldekloe/name v1.0.0


### PR DESCRIPTION
This way it's easier to import as we don't need to do an override which is giving some small QOL issues, e.g. you still need to manually do `go get github.com/dmarkham/enumer` in projects you use it.